### PR TITLE
Create an org-level SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security
+
+Per the [Linux Foundation Vulnerability Disclosure Policy](https://www.linuxfoundation.org/security), 
+if you find a vulnerability in a project maintained by the Open Source Security Foundation (OpenSSF), 
+please report that directly to the project maintaining that code, preferably using 
+GitHub's [Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability).
+
+If you've been unable to find a way to report it, or have received no response after repeated attempts,
+please contact the OpenSSF security contact email, [security@openssf.org](mailto:security@openssf.org).
+
+Thank you.


### PR DESCRIPTION
This PR adds a generic SECURITY.md, applicable to all projects within the ossf organization.